### PR TITLE
Update dependencies and bump minor version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "vesc-comm"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Ferdia McKeogh <ferdia@mckeogh.tech>"]
-edition = "2018"
+edition = "2021"
 keywords = ["nostd", "robotics", "embedded-hal-driver"]
 category = "embedded"
 license = "MPL-2.0"
@@ -11,12 +11,12 @@ description = "An embedded Rust library for communicating with VESCs"
 readme = "README.md"
 
 [dependencies]
-byteorder = { version = "1.3.1", default-features = false }
-nb = "0.1.1"
-embedded-hal = "0.2.2"
-failure = { version = "0.1.5", default-features = false, features = ["derive"] }
-heapless = { version = "0.4.1", features = ["const-fn"] }
+byteorder = { version = "1.4.3", default-features = false }
+nb = "1.0.0"
+embedded-hal = "0.2.7"
+failure = { version = "0.1.8", default-features = false, features = ["derive"] }
+heapless = "0.7.16"
 crc16 = "0.4.0"
 
 [dev-dependencies]
-serialport = "3.2.0"
+serialport = "4.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate nb;
 use byteorder::{BigEndian, ByteOrder};
 use embedded_hal::serial::{Read, Write};
 use failure::Fail;
-use heapless::{consts::U128, Vec};
+use heapless::Vec;
 
 pub mod responses;
 
@@ -139,7 +139,7 @@ fn write_packet<W: Write<u8>>(payload: &[u8], w: &mut W) -> nb::Result<(), Error
 }
 
 // Reads a packet, checks it and returns it's payload
-fn read_packet<R: Read<u8>>(r: &mut R) -> nb::Result<Vec<u8, U128>, Error> {
+fn read_packet<R: Read<u8>>(r: &mut R) -> nb::Result<Vec<u8, 128>, Error> {
     let mut payload = Vec::new();
 
     // Read correct number of bytes into payload


### PR DESCRIPTION
The heapless upgrade is backwards incompatible, so therefore bumping the minor version.